### PR TITLE
[D5] 사진 선택 화면 navigation 적용

### DIFF
--- a/IKU/IKU/Views/NavigationViewController.swift
+++ b/IKU/IKU/Views/NavigationViewController.swift
@@ -33,5 +33,9 @@ class NavigationViewController: UIViewController {
     
     @objc private func buttonTouched(_ sender: UIButton?) {
         navigationController?.pushViewController(SelectPhotoViewController(), animated: true)
+        let backItem = UIBarButtonItem()
+        backItem.title = ""
+        backItem.tintColor = .white
+        navigationItem.backBarButtonItem = backItem
     }
 }

--- a/IKU/IKU/Views/SelectPhotoViewController.swift
+++ b/IKU/IKU/Views/SelectPhotoViewController.swift
@@ -34,6 +34,7 @@ final class SelectPhotoViewController: UIViewController {
     
     private func configureNavigationBar() {
         let selectButton = UIBarButtonItem(title: "선택하기", style: .plain, target: self, action: #selector(selectButtonTouched(_:)))
+        selectButton.tintColor = .white
         navigationItem.rightBarButtonItem = selectButton
     }
     

--- a/IKU/IKU/Views/SelectPhotoViewController.swift
+++ b/IKU/IKU/Views/SelectPhotoViewController.swift
@@ -18,6 +18,7 @@ final class SelectPhotoViewController: UIViewController {
         return hostingController
     }()
     private var scrubberHostingController: UIHostingController<ScrubberView>?
+    private var capturedImage: UIImage? = nil
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +34,8 @@ final class SelectPhotoViewController: UIViewController {
     }
     
     private func configureNavigationBar() {
-        let selectButton = UIBarButtonItem(title: "선택하기", style: .plain, target: self, action: #selector(selectButtonTouched(_:)))
+        let barButtonTitle = self.capturedImage == nil ? "선택하기" : "완료"
+        let selectButton = UIBarButtonItem(title: barButtonTitle, style: .plain, target: self, action: #selector(selectButtonTouched(_:)))
         selectButton.tintColor = .white
         navigationItem.rightBarButtonItem = selectButton
     }
@@ -133,16 +135,39 @@ final class SelectPhotoViewController: UIViewController {
         generator.requestedTimeToleranceAfter = .zero
         generator.generateCGImageAsynchronously(for: time) { image, _, _ in
             DispatchQueue.main.async { [weak self] in
-                let imageViewController = ImageViewController()
-                self?.present(imageViewController, animated: true)
-                imageViewController.imageView.image = UIImage(cgImage: image!)
+                if let savedImage = self?.capturedImage,
+                   let cgImage = image {
+                    self?.player.pause()
+                    
+                    let imageViewController = ImageViewController()
+                    imageViewController.leftImageView.image = savedImage
+                    imageViewController.rightImageView.image = UIImage(cgImage: cgImage)
+                    
+                    self?.present(imageViewController, animated: true)
+                } else if let cgImage = image {
+                    self?.player.pause()
+                    
+                    let nextViewController = SelectPhotoViewController()
+                    nextViewController.capturedImage = UIImage(cgImage: cgImage)
+                    self?.navigationController?.pushViewController(nextViewController, animated: true)
+                    
+                    let backItem = UIBarButtonItem()
+                    backItem.title = ""
+                    backItem.tintColor = .white
+                    self?.navigationItem.backBarButtonItem = backItem
+                }
             }
         }
     }
 }
 
 fileprivate class ImageViewController: UIViewController {
-    let imageView: UIImageView = {
+    let leftImageView: UIImageView = {
+        let uiImageView = UIImageView()
+        uiImageView.contentMode = .scaleAspectFit
+        return uiImageView
+    }()
+    let rightImageView: UIImageView = {
         let uiImageView = UIImageView()
         uiImageView.contentMode = .scaleAspectFit
         return uiImageView
@@ -154,14 +179,22 @@ fileprivate class ImageViewController: UIViewController {
     }
     
     private func configureView() {
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(imageView)
-        
+        leftImageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(leftImageView)
         NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: view.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            leftImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            leftImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            leftImageView.trailingAnchor.constraint(equalTo: view.centerXAnchor),
+            leftImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        rightImageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(rightImageView)
+        NSLayoutConstraint.activate([
+            rightImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            rightImageView.leadingAnchor.constraint(equalTo: view.centerXAnchor),
+            rightImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            rightImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 }


### PR DESCRIPTION
# 이슈번호
🔐 close #10
🔐 close #17

# 내용
- 상단 navigation bar의 버튼 색이 하얀색이어야 하기에, 색을 하얗게 변경하였습니다.
- SelectPhotoView가 양안, 단안중 어떤 상태를 찍으려는지는 capturedImage: UIImage? 의 존재 여부로 분기합니다.
- 사진이 잘 capture 되었는지 확인하기 위해 ImageViewController를 변경해두었습니다.

# 테스트 방법(Optional)
- 앱을 시작한 후, 버튼을 눌러 다음 화면으로 넘어갑니다.
- 선택하고 싶은 프레임까지 재생버튼 또는 하단 스크롤을 이용하여 이동합니다.
- 화면 상단 우측 선택하기 버튼을 누릅니다.
- 동일하게 선택하고 싶은 프레임까지 재생버튼 또는 하단 스크롤을 이용하여 이동합니다.
- 하면 상단 우측 완료 버튼을 누릅니다.
- 캡쳐된 두 사진이 나오면 끝
- 필요시 백버튼도 테스트 해주시면 감사드리겠습니다.

# 스크린샷(Optional)
<img src="https://user-images.githubusercontent.com/81242125/201567952-39a7b058-1da9-47de-9c1f-bc7ca052fa3c.gif">

