### PR TITLE
[D5] 사진 선택 화면 안내 문구

### DIFF
--- a/IKU/IKU/Views/SelectPhotoViewController.swift
+++ b/IKU/IKU/Views/SelectPhotoViewController.swift
@@ -10,6 +10,14 @@ import AVFoundation
 
 final class SelectPhotoViewController: UIViewController {
     private let player = AVPlayer()
+    private lazy var announcementLabel: UILabel = {
+        let uiLabel = UILabel()
+        uiLabel.font = .systemFont(ofSize: 13)
+        uiLabel.textColor = .white
+        uiLabel.text = capturedImage == nil ?
+            "양쪽 눈이 보이는 상태의 화면을 선택해주세요" : "한쪽 눈을 가린 상태의 화면을 선택해주세요"
+        return uiLabel
+    }()
     private let playerView: PlayerView = PlayerView()
     private let playPauseButtonHostingController: UIHostingController<PlayButton> = {
         let hostingController = UIHostingController(rootView: PlayButton())
@@ -63,14 +71,20 @@ final class SelectPhotoViewController: UIViewController {
     private func configureViews() {
         view.backgroundColor = #colorLiteral(red: 0.1688045561, green: 0.1888649762, blue: 0.1928240955, alpha: 1)
         
+        view.addSubview(announcementLabel)
+        announcementLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            announcementLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            announcementLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+        
         playerView.addGestureRecognizer(
             UITapGestureRecognizer(target: self, action: #selector(playPauseButtonTouched))
         )
-        
         view.addSubview(playerView)
         playerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            playerView.topAnchor.constraint(equalTo: view.topAnchor),
+            playerView.topAnchor.constraint(equalTo: announcementLabel.bottomAnchor, constant: 16),
             playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])


### PR DESCRIPTION
# 이슈번호
🔐 close #20 
🔐 close #21 

# 내용
- 안내 문구를 넣었습니다.
- 이전 commit과 동일하게, capturedImage의 존재 여부에 따라 분기하였습니다.

# 테스트 방법(Optional)
- 선택하기 버튼과, back 버튼을 반복적으로 누르면서 안내 문구의 차이를 확인하시면 됩니다.

# 스크린샷(Optional)
<img height=400 src="https://user-images.githubusercontent.com/81242125/201697591-e5d51217-38be-4735-9205-eb237acc2cd4.jpeg"> <img height=400 src="https://user-images.githubusercontent.com/81242125/201697813-f3ef9f7a-e086-4070-aa0b-1a138d4d170c.jpeg">