### PR TITLE
[D5] 탭바 중 사시검사탭과 View 연결하는 로직 구현

### DIFF
--- a/IKU/IKU/App/SceneDelegate.swift
+++ b/IKU/IKU/App/SceneDelegate.swift
@@ -21,9 +21,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         //탭바컨트롤러의 생성
         let tabBarVC = UITabBarController()
         
-     
+        //UIKit의 탭바에 SwiftUI로 만든 View 넣기 위한 작업
+        let storyViewController: UIViewController = UIHostingController<StoryView>(rootView: StoryView())
+        
         //첫번째 화면은 일단
-        let testVC = ViewController()
+        let testVC = storyViewController
         let historyVC = HistoryViewController()
         let dictionaryVC = DictionaryViewController()
         


### PR DESCRIPTION
# 이슈번호
🔐 close #52

# 내용
탭바에서 사시검사탭을 눌렀을 때 나오는 View인 StoryView를 연결하는 로직을 구현했습니다.
`UIHostingController`를 이용하는 간단한 작업이였습니다.

# 테스트 방법(Optional)
탭바에서 사시검사 탭을 눌러보면 테스트가 가능합니다.

# 스크린샷(Optional)
![Simulator Screen Shot - iPhone 13 - 2022-11-18 at 10 45 13](https://user-images.githubusercontent.com/103012763/202597615-4d65d629-4b52-4317-83e6-162ed676e7e7.png)


