### PR TITLE
[D5] 사시각 결과를 JSON으로 저장하는 객체 생성

### DIFF
--- a/IKU/IKU.xcodeproj/project.pbxproj
+++ b/IKU/IKU.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		A8B5349D2926752200237C30 /* SQLiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B5349C2926752200237C30 /* SQLiteService.swift */; };
 		A8B534A52926755900237C30 /* PersistenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B534A42926755900237C30 /* PersistenceTest.swift */; };
 		A8B534AB2926756600237C30 /* SQLiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B5349C2926752200237C30 /* SQLiteService.swift */; };
+		A8FA007B292B45BE0091EDC2 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FA007A292B45BE0091EDC2 /* PersistenceManager.swift */; };
+		A8FA007D292B45D00091EDC2 /* JSONService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FA007C292B45D00091EDC2 /* JSONService.swift */; };
+		A8FA007F292B45E00091EDC2 /* JSONServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FA007E292B45E00091EDC2 /* JSONServiceTest.swift */; };
+		A8FA0080292B46330091EDC2 /* JSONService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FA007C292B45D00091EDC2 /* JSONService.swift */; };
 		A8FACE3029271C2900BF2CD0 /* Eye.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FACE2F29271C2900BF2CD0 /* Eye.swift */; };
 		C70100F02921D0DE00B58231 /* CoverTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70100EF2921D0DE00B58231 /* CoverTestViewController.swift */; };
 		C70100F42921DF7A00B58231 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70100F32921DF7A00B58231 /* UIViewController+Extension.swift */; };
@@ -124,6 +128,9 @@
 		A8B5349C2926752200237C30 /* SQLiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteService.swift; sourceTree = "<group>"; };
 		A8B534A22926755900237C30 /* PersistenceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PersistenceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8B534A42926755900237C30 /* PersistenceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTest.swift; sourceTree = "<group>"; };
+		A8FA007A292B45BE0091EDC2 /* PersistenceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		A8FA007C292B45D00091EDC2 /* JSONService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONService.swift; sourceTree = "<group>"; };
+		A8FA007E292B45E00091EDC2 /* JSONServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONServiceTest.swift; sourceTree = "<group>"; };
 		A8FACE2F29271C2900BF2CD0 /* Eye.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Eye.swift; sourceTree = "<group>"; };
 		C70100EF2921D0DE00B58231 /* CoverTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverTestViewController.swift; sourceTree = "<group>"; };
 		C70100F32921DF7A00B58231 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
@@ -307,6 +314,8 @@
 		A8B2A2A4291C8DFD000F5624 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				A8FA007A292B45BE0091EDC2 /* PersistenceManager.swift */,
+				A8FA007C292B45D00091EDC2 /* JSONService.swift */,
 				A8B5349C2926752200237C30 /* SQLiteService.swift */,
 				A8B2A2A7291C8E3B000F5624 /* ManagerPlaceholder.swift */,
 				C7537CF9292320B5001E8BF6 /* VideoManager.swift */,
@@ -328,6 +337,7 @@
 			isa = PBXGroup;
 			children = (
 				A8B534A42926755900237C30 /* PersistenceTest.swift */,
+				A8FA007E292B45E00091EDC2 /* JSONServiceTest.swift */,
 			);
 			path = PersistenceTest;
 			sourceTree = "<group>";
@@ -526,6 +536,7 @@
 				A8B2A29F291C8D4B000F5624 /* DataPlaceholder.swift in Sources */,
 				A8B2A2B3291CCDAD000F5624 /* PlayerView.swift in Sources */,
 				A804661C292012B10079CEDC /* PlayButton.swift in Sources */,
+				A8FA007B292B45BE0091EDC2 /* PersistenceManager.swift in Sources */,
 				C74491D4291D54DC00166197 /* CVCalendarMenuViewDelegate.swift in Sources */,
 				C7F1775E2925B1CD0004C5D9 /* ARFrameGenerator.swift in Sources */,
 				C74491DE291D54DC00166197 /* CVCalendarContentPresentationCoordinator.swift in Sources */,
@@ -571,6 +582,7 @@
 				C7F1775D2925B1CD0004C5D9 /* ARAssetWriter.swift in Sources */,
 				C70100F42921DF7A00B58231 /* UIViewController+Extension.swift in Sources */,
 				C74491E4291D54DC00166197 /* CVCalendarViewAnimatorDelegate.swift in Sources */,
+				A8FA007D292B45D00091EDC2 /* JSONService.swift in Sources */,
 				C74491D5291D54DC00166197 /* CVCalendarContentViewController.swift in Sources */,
 				C75B19FC291E30D6005B1A22 /* StrabismusLog.swift in Sources */,
 				C7449160291D4B4700166197 /* UIFont+Extension.swift in Sources */,
@@ -589,8 +601,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8FA007F292B45E00091EDC2 /* JSONServiceTest.swift in Sources */,
 				A8B534A52926755900237C30 /* PersistenceTest.swift in Sources */,
 				A8B534AB2926756600237C30 /* SQLiteService.swift in Sources */,
+				A8FA0080292B46330091EDC2 /* JSONService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IKU/IKU.xcodeproj/xcshareddata/xcschemes/IKU.xcscheme
+++ b/IKU/IKU.xcodeproj/xcshareddata/xcschemes/IKU.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A8B2A282291C8B2F000F5624"
+               BuildableName = "IKU.app"
+               BlueprintName = "IKU"
+               ReferencedContainer = "container:IKU.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A8B534A12926755900237C30"
+               BuildableName = "PersistenceTest.xctest"
+               BlueprintName = "PersistenceTest"
+               ReferencedContainer = "container:IKU.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A8B2A282291C8B2F000F5624"
+            BuildableName = "IKU.app"
+            BlueprintName = "IKU"
+            ReferencedContainer = "container:IKU.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A8B2A282291C8B2F000F5624"
+            BuildableName = "IKU.app"
+            BlueprintName = "IKU"
+            ReferencedContainer = "container:IKU.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/IKU/IKU.xcodeproj/xcshareddata/xcschemes/PersistenceTest.xcscheme
+++ b/IKU/IKU.xcodeproj/xcshareddata/xcschemes/PersistenceTest.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A8B534A12926755900237C30"
+               BuildableName = "PersistenceTest.xctest"
+               BlueprintName = "PersistenceTest"
+               ReferencedContainer = "container:IKU.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/IKU/IKU/Manager/JSONService.swift
+++ b/IKU/IKU/Manager/JSONService.swift
@@ -1,0 +1,53 @@
+//
+//  JSONService.swift
+//  IKU
+//
+//  Created by Shin Jae Ung on 2022/11/21.
+//
+
+import Foundation
+
+final class JSONService {
+    private let path: String = "strabismusAngles"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let url: URL
+    
+    init() throws {
+        self.url = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ).appendingPathComponent(path)
+        
+        try createFolderIfNotExists()
+    }
+    
+    private func createFolderIfNotExists() throws {
+        if !FileManager.default.fileExists(atPath: url.path()) {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+    }
+    
+    func fetch(toFileName name: String) throws -> StrabismusAngle { 
+        let url = url.appendingPathComponent(name, conformingTo: .json)
+        let jsonData = try Data(contentsOf: url)
+        return try decoder.decode(StrabismusAngle.self, from: jsonData)
+    }
+    
+    func save(toFileName name: String, with dictionary: [Double: Double]) throws {
+        let strabismusAngle = StrabismusAngle(fileName: name, dictionary: dictionary)
+        let encodedData = try encoder.encode(strabismusAngle)
+        try encodedData.write(to: url.appendingPathComponent(name, conformingTo: .json))
+    }
+    
+    func delete(ofFileName name: String) throws {
+        try FileManager.default.removeItem(at: url.appendingPathComponent(name, conformingTo: .json))
+    }
+}
+
+struct StrabismusAngle: Codable {
+    let fileName: String
+    let dictionary: [Double: Double]
+}

--- a/IKU/IKU/Manager/PersistenceManager.swift
+++ b/IKU/IKU/Manager/PersistenceManager.swift
@@ -1,0 +1,19 @@
+//
+//  PersistenceManager.swift
+//  IKU
+//
+//  Created by Shin Jae Ung on 2022/11/21.
+//
+
+import Foundation
+
+final class PersistenceManager {
+    let sqliteService: SQLiteService
+    let jsonService: JSONService
+    
+    init() throws {
+        try self.sqliteService = SQLiteService()
+        try self.sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try self.jsonService = JSONService()
+    }
+}

--- a/IKU/PersistenceTest/JSONServiceTest.swift
+++ b/IKU/PersistenceTest/JSONServiceTest.swift
@@ -1,0 +1,57 @@
+//
+//  JSONServiceTest.swift
+//  PersistenceTest
+//
+//  Created by Shin Jae Ung on 2022/11/21.
+//
+
+@testable import IKU
+import XCTest
+
+final class JSONServiceTest: XCTestCase {
+    var jsonService: JSONService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        jsonService = try JSONService()
+    }
+
+    override func tearDownWithError() throws {
+        let dbURL: URL = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ).appendingPathComponent("strabismusAngles")
+        try FileManager.default.removeItem(at: dbURL)
+        jsonService = nil
+        try super.tearDownWithError()
+    }
+
+    func test_save_data() throws {
+        XCTAssertNoThrow(try jsonService.save(toFileName: "test", with: [:]))
+    }
+    
+    func test_save_data_and_check_if_it_is_in() throws {
+        try jsonService.save(toFileName: "test", with: [:])
+        let allFileNames = try allFileNamesInDirectory()
+        XCTAssertEqual(allFileNames.count, 1)
+        XCTAssertEqual(allFileNames.first, "test.json")
+    }
+    
+    func test_delete_data() throws {
+        try jsonService.save(toFileName: "test", with: [:])
+        XCTAssertNoThrow(try jsonService.delete(ofFileName: "test"))
+    }
+    
+    private func allFileNamesInDirectory() throws -> [String] {
+        let dbURL: URL = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ).appendingPathComponent("strabismusAngles")
+        return try FileManager.default.contentsOfDirectory(atPath: dbURL.path())
+    }
+
+}


### PR DESCRIPTION
# 이슈번호
🔓 open #39

# 내용
- ARKit에서 측정된 사시각들을 JSON으로 저장하는 객체를 생성하였습니다.
  - App의 document 폴더에 strabismusAngles라는 폴더를 만듭니다.
  - data 저장시 save(toFileName:) 함수를 호출합니다.
    - StrabismusAngle이라는 객체를 만들어 해당 폴더에 특정 이름으로 json파일을 만듭니다.
  - data를 가져올 시 fetch(toFileName:) 함수를 호출합니다.
    - StrabismusAngle이라는 객체를 만들어 반환합니다.
  - data 삭제시 delete(ofFilename:) 함수를 호출합니다.

# 테스트 방법(Optional)
- UnitTest 참조 바랍니다.
