### PR TITLE
[D2] Persistence manager 구현

### DIFF
--- a/IKU/IKU.xcodeproj/project.pbxproj
+++ b/IKU/IKU.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		A89F2307292BB3A6000B3D63 /* VideoURLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F2306292BB3A6000B3D63 /* VideoURLService.swift */; };
 		A89F2309292BB3B0000B3D63 /* VideoURLServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F2308292BB3B0000B3D63 /* VideoURLServiceTest.swift */; };
 		A89F230A292BB3B5000B3D63 /* VideoURLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F2306292BB3A6000B3D63 /* VideoURLService.swift */; };
+		A89F230C292BB648000B3D63 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F230B292BB648000B3D63 /* PersistenceManager.swift */; };
+		A89F230E292BB64D000B3D63 /* PersistenceManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F230D292BB64D000B3D63 /* PersistenceManagerTest.swift */; };
+		A89F230F292BB650000B3D63 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F230B292BB648000B3D63 /* PersistenceManager.swift */; };
 		A8AA21292922131D00EFBE27 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AA21282922131D00EFBE27 /* GradientView.swift */; };
 		A8B2A287291C8B2F000F5624 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B2A286291C8B2F000F5624 /* AppDelegate.swift */; };
 		A8B2A289291C8B2F000F5624 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B2A288291C8B2F000F5624 /* SceneDelegate.swift */; };
@@ -120,6 +123,8 @@
 		A89F22F9292B7079000B3D63 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
 		A89F2306292BB3A6000B3D63 /* VideoURLService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoURLService.swift; sourceTree = "<group>"; };
 		A89F2308292BB3B0000B3D63 /* VideoURLServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoURLServiceTest.swift; sourceTree = "<group>"; };
+		A89F230B292BB648000B3D63 /* PersistenceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		A89F230D292BB64D000B3D63 /* PersistenceManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistenceManagerTest.swift; sourceTree = "<group>"; };
 		A8AA21282922131D00EFBE27 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		A8B2A283291C8B2F000F5624 /* IKU.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IKU.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8B2A286291C8B2F000F5624 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -328,6 +333,7 @@
 		A8B2A2A4291C8DFD000F5624 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				A89F230B292BB648000B3D63 /* PersistenceManager.swift */,
 				A8FA007C292B45D00091EDC2 /* JSONService.swift */,
 				A8B5349C2926752200237C30 /* SQLiteService.swift */,
 				A89F2306292BB3A6000B3D63 /* VideoURLService.swift */,
@@ -351,6 +357,7 @@
 		A8B534A32926755900237C30 /* PersistenceTest */ = {
 			isa = PBXGroup;
 			children = (
+				A89F230D292BB64D000B3D63 /* PersistenceManagerTest.swift */,
 				A8B534A42926755900237C30 /* SQLiteServiceTest.swift */,
 				A8FA007E292B45E00091EDC2 /* JSONServiceTest.swift */,
 				A89F2308292BB3B0000B3D63 /* VideoURLServiceTest.swift */,
@@ -593,6 +600,7 @@
 				C7422514291F304E00DB6D80 /* CVMonth.swift in Sources */,
 				C74491D9291D54DC00166197 /* CVCalendarWeekContentViewController.swift in Sources */,
 				C74491DC291D54DC00166197 /* CVAuxiliaryView.swift in Sources */,
+				A89F230C292BB648000B3D63 /* PersistenceManager.swift in Sources */,
 				C72601E529278642009AB7D1 /* UIView+Extension.swift in Sources */,
 				A8B2A2A8291C8E3B000F5624 /* ManagerPlaceholder.swift in Sources */,
 				C74491E2291D54DC00166197 /* CVCalendarViewPresentationMode.swift in Sources */,
@@ -621,6 +629,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A8FA007F292B45E00091EDC2 /* JSONServiceTest.swift in Sources */,
+				A89F230F292BB650000B3D63 /* PersistenceManager.swift in Sources */,
+				A89F230E292BB64D000B3D63 /* PersistenceManagerTest.swift in Sources */,
 				A89F2309292BB3B0000B3D63 /* VideoURLServiceTest.swift in Sources */,
 				A8B534A52926755900237C30 /* SQLiteServiceTest.swift in Sources */,
 				A89F230A292BB3B5000B3D63 /* VideoURLService.swift in Sources */,

--- a/IKU/IKU/Manager/PersistenceManager.swift
+++ b/IKU/IKU/Manager/PersistenceManager.swift
@@ -1,0 +1,92 @@
+//
+//  PersistenceManager.swift
+//  IKU
+//
+//  Created by Shin Jae Ung on 2022/11/21.
+//
+
+import Foundation
+
+final class PersistenceManager {
+    enum Term {
+        case all
+        case at(day: Date)
+    }
+    
+    private let sqliteService: SQLiteService
+    private let jsonService: JSONService
+    private let videoURLService: VideoURLService
+    private let url: URL
+    
+    init() throws {
+        self.url = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        
+        try self.sqliteService = SQLiteService(url: self.url)
+        try self.sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try self.jsonService = JSONService(url: self.url)
+        try self.videoURLService = VideoURLService(url: self.url)
+    }
+    
+    func clearGarbageFilesInDocumentFolder() throws {
+        let usingFiles: [String] = [SQLiteService.path, JSONService.path, VideoURLService.path]
+        let fileNamesOfGarbageFiles = try FileManager.default.contentsOfDirectory(atPath: url.path())
+            .filter { !usingFiles.contains($0) }
+        try fileNamesOfGarbageFiles.forEach {
+            try FileManager.default.removeItem(at: url.appendingPathComponent($0))
+        }
+    }
+    
+    func save(
+        videoURL: URL,
+        withARKitResult dictionay: [Double: Double],
+        isLeftEye: Bool,
+        uncoveredPhotoTime: Double,
+        coveredPhotoTime: Double,
+        creationDate: Double = Date.now.timeIntervalSince1970,
+        isBookMarked: Bool = false
+    ) throws {
+        let newFileName = UUID().uuidString
+        let measurementResult = MeasurementResult(
+            localIdentifier: newFileName,
+            isLeftEye: isLeftEye,
+            timeOne: uncoveredPhotoTime,
+            timeTwo: coveredPhotoTime,
+            creationDate: creationDate,
+            isBookMarked: isBookMarked
+        )
+        try jsonService.save(
+            toFileName: newFileName,
+            with: dictionay
+        )
+        try videoURLService.moveURLToVideoFolder(
+            videoURL,
+            withChangingNameTo: newFileName
+        )
+        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+    }
+    
+    func fetchVideo(_ day: Term) throws -> [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] {
+        switch day {
+        case .all:
+            return try fetchVideo(from: try sqliteService.select(byQuery: .allVideos))
+        case .at(let day):
+            return try fetchVideo(from: try sqliteService.select(byQuery: .videoForSpecipic(day: day)))
+        }
+    }
+    
+    private func fetchVideo(from measurementResults: [MeasurementResult]) throws -> [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] {
+        return try measurementResults.map { measurementResult in
+            let fileName = measurementResult.localIdentifier
+            let videoURL = try videoURLService.fetchVideoURL(named: fileName)
+            let angles = try jsonService.fetch(toFileName: fileName).dictionary
+            return ((videoURL, angles, measurementResult))
+        }
+    }
+}
+
+

--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -1,0 +1,87 @@
+//
+//  PersistenceManagerTest.swift
+//  PersistenceTest
+//
+//  Created by Shin Jae Ung on 2022/11/21.
+//
+
+import XCTest
+
+final class PersistenceManagerTest: XCTestCase {
+    var persistenceManager: PersistenceManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.persistenceManager = try PersistenceManager()
+    }
+
+    override func tearDownWithError() throws {
+        let dbURL: URL = try documentFolderURL()
+        persistenceManager = nil
+        for item in try allFileNamesInDocumentDirectory() {
+            try FileManager.default.removeItem(at: dbURL.appendingPathComponent(item))
+        }
+        try super.tearDownWithError()
+    }
+
+    func test_save_video_without_prefixed_values() throws {
+        try persistenceManager.save(
+            videoURL: try testFileURLWithCreatingFile(),
+            withARKitResult: [:],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2
+        )
+    }
+    
+    func test_save_video_with_all_values() throws {
+        try persistenceManager.save(
+            videoURL: try testFileURLWithCreatingFile(),
+            withARKitResult: [:],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2,
+            creationDate: Date.now.timeIntervalSince1970,
+            isBookMarked: false
+        )
+    }
+    
+    func test_fetch_all_video() throws {
+        try persistenceManager.save(
+            videoURL: try testFileURLWithCreatingFile(),
+            withARKitResult: [2.2:3.3],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2,
+            creationDate: 1234567,
+            isBookMarked: false
+        )
+        let result = try persistenceManager.fetchVideo(.all)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.angles, [2.2:3.3])
+        XCTAssertEqual(result.first?.measurementResult.isLeftEye, true)
+        XCTAssertEqual(result.first?.measurementResult.timeOne, 0)
+        XCTAssertEqual(result.first?.measurementResult.timeTwo, 1.2)
+        XCTAssertEqual(result.first?.measurementResult.creationDate, 1234567)
+        XCTAssertEqual(result.first?.measurementResult.isBookMarked, false)
+    }
+    
+    func test_clear_garbage_files() throws {
+        _ = try testFileURLWithCreatingFile()
+        var expectedFiles: Set<String> = ["example.mp4", "strabismusAngles", "videos", "IKU.sqlite"]
+        
+        for fileName in try allFileNamesInDocumentDirectory() {
+            XCTAssertTrue(expectedFiles.contains(fileName))
+            expectedFiles.remove(fileName)
+        }
+        
+        try persistenceManager.clearGarbageFilesInDocumentFolder()
+        
+        expectedFiles = ["strabismusAngles", "videos", "IKU.sqlite"]
+        
+        for fileName in try allFileNamesInDocumentDirectory() {
+            XCTAssertTrue(expectedFiles.contains(fileName))
+            expectedFiles.remove(fileName)
+        }
+    }
+}


### PR DESCRIPTION
# 이슈번호
🔐 close #39 

# 내용
- SQLiteService, JSONService, VideoURLService를 소유하고, 처리하는 PersistenceManager를 구현하였습니다.
- 세 객체를 따로 호출할 필요 없이, PersistenceManager하나만을 이용해 쉽게 저장하고, 삭제할 수 있습니다.
- 다만, CoverTestViewController에서 측정이 시작되기만 하면 저장하지 않더라도 무조건 Document folder에 파일이 저장되기 때문에
  - 주기적으로 `clearGarbageFilesInDocumentFolder()` 함수를 호출하여야 합니다.

# 테스트 방법(Optional)
- UnitTest 참조 바랍니다.