### PR TITLE
[D1] 검사 데이터 저장 및 조회

### DIFF
--- a/IKU/IKU/App/SceneDelegate.swift
+++ b/IKU/IKU/App/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         //첫번째 화면은 일단
         let testVC = UINavigationController(rootViewController: UIHostingController<StoryView>(rootView: StoryView()))
-        let historyVC = HistoryViewController()
+        let historyVC = UINavigationController(rootViewController: HistoryViewController()) 
         let dictionaryVC = DictionaryViewController()
         
         //탭바 이름들 설정

--- a/IKU/IKU/Data/TestGuideString.swift
+++ b/IKU/IKU/Data/TestGuideString.swift
@@ -29,7 +29,7 @@ enum TestGuide: Equatable {
         case .isReady, .incorrectDistance, .testComplete:
             return self.voiceText
         case .uncover, .coverTo(_):
-            return self.voiceText + "3초"
+            return self.voiceText + " 3초"
         }
     }
 }

--- a/IKU/IKU/Views/CoverTestViewModel.swift
+++ b/IKU/IKU/Views/CoverTestViewModel.swift
@@ -104,7 +104,6 @@ class CoverTestViewModel: NSObject {
     // Guide
     func initAVSpeechsynthesizer() {
         avSpeechSynthesizer = AVSpeechSynthesizer()
-        avSpeechSynthesizer?.delegate = self
     }
     
     func playVoiceGuide(text: String) {
@@ -200,31 +199,4 @@ extension CoverTestViewModel: ARSessionDelegate, ARSCNViewDelegate {
         }
         faceAnchors[faceAnchor] = nil
     }
-}
-
-extension CoverTestViewModel: AVSpeechSynthesizerDelegate {
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
-        print(#function)
-    }
-    
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, willSpeakRangeOfSpeechString: NSRange, utterance: AVSpeechUtterance) {
-        print(#function)
-    }
-    
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, didPause: AVSpeechUtterance) {
-        print(#function)
-    }
-    
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, didContinue: AVSpeechUtterance) {
-        print(#function)
-    }
-    
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, didFinish: AVSpeechUtterance) {
-        print(#function)
-    }
-    
-    func speechSynthesizer( _ synthesizer: AVSpeechSynthesizer, didCancel: AVSpeechUtterance) {
-        print(#function)
-    }
-
 }

--- a/IKU/IKU/Views/HistoryViewController.swift
+++ b/IKU/IKU/Views/HistoryViewController.swift
@@ -79,6 +79,16 @@ final class HistoryViewController: UIViewController {
         ])
     }
     
+    private func fetchData() {
+        do {
+            let persistenceManager = try PersistenceManager()
+            ikuCalendarView.calendarView.data = try persistenceManager.fetchVideo(.all)
+        } catch {
+            // TODO: Merge 후 수정
+            self.showAlertController(title: "데이터 불러오기 실패", message: "검사 결과를 불러오는데 실패하였습니다.", completeHandler: {})
+        }
+    }
+    
     private func goToResultView() {
         // TODO: - 결과뷰 Present
     }
@@ -116,8 +126,18 @@ final class HistoryViewController: UIViewController {
         setupLayoutConstraint()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchData()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        ikuCalendarView.commitCalendarViewUpdate()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         ikuCalendarView.commitCalendarViewUpdate()
     }
 }

--- a/IKU/IKU/Views/HistoryViewController.swift
+++ b/IKU/IKU/Views/HistoryViewController.swift
@@ -49,8 +49,8 @@ final class HistoryViewController: UIViewController {
     }()
     
     // MARK: - Methods
-    private func configureNavigationBar() {
-        
+    private func setupCalendarView() {
+        ikuCalendarView.didSelectDayView = goToResultView
     }
     
     private func setupLayoutConstraint() {
@@ -77,6 +77,10 @@ final class HistoryViewController: UIViewController {
             eyeSegmentedControl.widthAnchor.constraint(equalTo: ikuChartView.widthAnchor, multiplier: 0.5),
             eyeSegmentedControl.heightAnchor.constraint(equalTo: ikuChartView.heightAnchor, multiplier: 0.2),
         ])
+    }
+    
+    private func goToResultView() {
+        // TODO: - 결과뷰 Present
     }
     
     private func goToCoverTestView() {
@@ -108,7 +112,7 @@ final class HistoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .ikuBackground
-        configureNavigationBar()
+        setupCalendarView()
         setupLayoutConstraint()
     }
     

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarContentViewController.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarContentViewController.swift
@@ -14,8 +14,14 @@ open class CVCalendarContentViewController: UIViewController {
     public let previous = "Previous"
     public let presented = "Presented"
     public let following = "Following"
+    
 
     // MARK: - Public Properties
+    var data: [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] = []
+    func loadData(data: [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)]) {
+        self.data = data
+    }
+    
     public unowned let calendarView: CalendarView
     public let scrollView: UIScrollView
 

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarDayView.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarDayView.swift
@@ -81,6 +81,12 @@ public final class CVCalendarDayView: UIView {
         self.backgroundColor = .white
         date = dateWithWeekView(weekView, andWeekIndex: weekdayIndex)
         
+        if let persistenceManager = try? PersistenceManager(),
+           let resultDatas = try? persistenceManager.fetchVideo(.at(day: date.getDate())) {
+            isTested = !resultDatas.isEmpty
+        }
+    
+        
         interactionSetup()
         if !isOut {
             labelSetup()

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public final class CVCalendarMonthContentViewController: CVCalendarContentViewController, CVCalendarContentPresentationCoordinator {
     fileprivate var monthViews: [Identifier : MonthView]
-
+    
     public override init(calendarView: CalendarView, frame: CGRect) {
         monthViews = [Identifier : MonthView]()
         super.init(calendarView: calendarView, frame: frame)
@@ -30,7 +30,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
     }
 
     // MARK: - Load & Reload
-
+    
     public func initialLoad(_ date: Foundation.Date) {
         insertMonthView(getPreviousMonth(date), withIdentifier: previous)
         insertMonthView(presentedMonthView, withIdentifier: presented)

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarView.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 public typealias WeekView = CVCalendarWeekView
 public typealias CalendarView = CVCalendarView
@@ -40,6 +41,8 @@ public final class CVCalendarView: UIView {
     public var calendarMode: CalendarMode!
 
     public var (weekViewSize, dayViewSize): (CGSize?, CGSize?)
+    
+    @Published var data: [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] = []
 
     fileprivate var validated = false
     fileprivate var currentOrientation: UIDeviceOrientation
@@ -408,7 +411,7 @@ private extension CVCalendarView {
             switch delegate.presentationMode() {
                 case .monthView:
                     contentController =
-                        MonthContentViewController(calendarView: self, frame: bounds)
+                MonthContentViewController(calendarView: self, frame: bounds)
                 case .weekView:
                     contentController =
                         WeekContentViewController(calendarView: self, frame: bounds)

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVDate.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVDate.swift
@@ -42,6 +42,10 @@ public final class CVDate: NSObject {
 
         super.init()
     }
+    
+    public func getDate() -> Date {
+        self.date
+    }
 }
 
 extension CVDate {

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView+Extension.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView+Extension.swift
@@ -32,11 +32,10 @@ extension IKUCalendarView: CVCalendarViewDelegate, CVCalendarMenuViewDelegate {
     
     func didSelectDayView(_ dayView: CVCalendarDayView, animationDidFinish: Bool) {
         guard let persistenceManager = try? PersistenceManager(),
-              let resultDatas = try? persistenceManager.fetchVideo(.at(day: dayView.date.getDate())) else {
+              let resultData = try? persistenceManager.fetchVideo(.at(day: dayView.date.getDate())) else {
             return
         }
-        if !resultDatas.isEmpty {
-            print(resultDatas)
+        if !resultData.isEmpty {
             guard let didSelectDayView else { return }
             didSelectDayView()
         }

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView+Extension.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView+Extension.swift
@@ -31,7 +31,15 @@ extension IKUCalendarView: CVCalendarViewDelegate, CVCalendarMenuViewDelegate {
     func shouldAutoSelectDayOnMonthChange() -> Bool { return false }
     
     func didSelectDayView(_ dayView: CVCalendarDayView, animationDidFinish: Bool) {
-        print(#function)
+        guard let persistenceManager = try? PersistenceManager(),
+              let resultDatas = try? persistenceManager.fetchVideo(.at(day: dayView.date.getDate())) else {
+            return
+        }
+        if !resultDatas.isEmpty {
+            print(resultDatas)
+            guard let didSelectDayView else { return }
+            didSelectDayView()
+        }
     }
     
     func shouldShowCustomSingleSelection() -> Bool { return false }

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView.swift
@@ -25,7 +25,7 @@ final class IKUCalendarView: UIView {
     }
     
     var didSelectDayView: (() -> Void)?
-
+    
     // UI Properties
     lazy private var calendarHeaderView: UIView = {
         let view = UIView()
@@ -219,6 +219,8 @@ final class IKUCalendarView: UIView {
     @objc func tapMonthYearLabel(_ sender: UITapGestureRecognizer) {
         isMonthYearSelecting = datePicker.isHidden
         datePicker.isHidden = !datePicker.isHidden
+        
+        calendarView.data = []
         
         datePicker.selectRow(selectedDate.month - 1, inComponent: 0, animated: false)
         datePicker.selectRow(selectedDate.year - 2022 + 50, inComponent: 1, animated: false)

--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/IKUCalendarView.swift
@@ -23,6 +23,8 @@ final class IKUCalendarView: UIView {
         let max = currentYear + 50
         return Array(min...max)
     }
+    
+    var didSelectDayView: (() -> Void)?
 
     // UI Properties
     lazy private var calendarHeaderView: UIView = {


### PR DESCRIPTION
# 이슈번호
🔐 close #93

# 내용
- 검사 데이터를 저장할 수 있습니다.
- 달력에서 검사한 날을 확인할 수 있습니다.
    - 각 날짜에 해당하는 View는 검사결과를 가지고 있습니다.
    - 날짜를 터치했을때, 검사 결과가 있다면, 검사결과를 print 하고, 없다면 아무것도 작동하지 않습니다.
- 기타
    - CoverTestViewModel에서 사용되지 않는 AVSpeechSynthesizerDelegate가 삭제되었습니다.

# 테스트 방법(Optional)
- 검사 후 데이터를 저장한 후 캘린더에 검사완료 아이콘이 나타나는지 확인합니다.

# 스크린샷(Optional)
![IMG_4B056ABB5FCD-1](https://user-images.githubusercontent.com/47404421/203361566-31b6d03e-9710-4e3d-b686-abaa678dec17.jpeg)

