### PR TITLE
[D2] 영구저장소에서 삭제 함수 구현

### DIFF
--- a/IKU/IKU/Manager/PersistenceManager.swift
+++ b/IKU/IKU/Manager/PersistenceManager.swift
@@ -79,6 +79,12 @@ final class PersistenceManager {
         }
     }
     
+    func deleteVideo(withLocalIdentifier localIdentifier: String) throws {
+        try jsonService.delete(ofFileName: localIdentifier)
+        try videoURLService.deleteVideoURL(named: localIdentifier)
+        try sqliteService.delete(byQuery: .videoData(withLocalIdentifier: localIdentifier))
+    }
+    
     private func fetchVideo(from measurementResults: [MeasurementResult]) throws -> [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] {
         return try measurementResults.map { measurementResult in
             let fileName = measurementResult.localIdentifier

--- a/IKU/IKU/Manager/VideoURLService.swift
+++ b/IKU/IKU/Manager/VideoURLService.swift
@@ -39,4 +39,8 @@ final class VideoURLService {
             throw URLError.noFile
         }
     }
+    
+    func deleteVideoURL(named name: String) throws {
+        try FileManager.default.removeItem(at: url.appendingPathComponent(name + pathExtension))
+    }
 }

--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -66,6 +66,32 @@ final class PersistenceManagerTest: XCTestCase {
         XCTAssertEqual(result.first?.measurementResult.isBookMarked, false)
     }
     
+    func test_delete_video_throws_error_using_wrong_local_identifier() throws {
+        XCTAssertThrowsError(
+            try persistenceManager.deleteVideo(withLocalIdentifier: "wrongLocalIdentifier")
+        )
+    }
+    
+    func test_delete_video() throws {
+        try persistenceManager.save(
+            videoURL: try testFileURLWithCreatingFile(),
+            withARKitResult: [2.2:3.3],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2,
+            creationDate: 1234567,
+            isBookMarked: false
+        )
+        let resultsBeforeDeletion = try persistenceManager.fetchVideo(.all)
+        XCTAssertEqual(resultsBeforeDeletion.count, 1)
+        
+        guard let localIdentifier = resultsBeforeDeletion.first?.measurementResult.localIdentifier else { return }
+        try persistenceManager.deleteVideo(withLocalIdentifier: localIdentifier)
+        
+        let resultsAfterDeletion = try persistenceManager.fetchVideo(.all)
+        XCTAssertEqual(resultsAfterDeletion.count, 0)
+    }
+    
     func test_clear_garbage_files() throws {
         _ = try testFileURLWithCreatingFile()
         var expectedFiles: Set<String> = ["example.mp4", "strabismusAngles", "videos", "IKU.sqlite"]

--- a/IKU/PersistenceTest/SQLiteServiceTest.swift
+++ b/IKU/PersistenceTest/SQLiteServiceTest.swift
@@ -71,6 +71,46 @@ final class SQLiteServiceTest: XCTestCase {
         XCTAssertEqual(array.count, 10)
     }
     
+    func test_delete_data() throws {
+        let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
+        let measurementResult = MeasurementResult(
+            localIdentifier: localIdentifier,
+            isLeftEye: true,
+            timeOne: 0,
+            timeTwo: 1.2,
+            creationDate: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
+            isBookMarked: false
+        )
+        try sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        
+        XCTAssertNoThrow(
+            try sqliteService.delete(byQuery: .videoData(withLocalIdentifier: localIdentifier))
+        )
+    }
+    
+    func test_delete_data_and_check_if_it_exists() throws {
+        let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
+        let measurementResult = MeasurementResult(
+            localIdentifier: localIdentifier,
+            isLeftEye: true,
+            timeOne: 0,
+            timeTwo: 1.2,
+            creationDate: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
+            isBookMarked: false
+        )
+        try sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        
+        let resultsBeforeDeletion = try sqliteService.select(byQuery: .videoForSpecipic(day: "2022-11-22 00:12:34".toDate()!))
+        XCTAssertEqual(resultsBeforeDeletion.count, 1)
+        
+        try sqliteService.delete(byQuery: .videoData(withLocalIdentifier: localIdentifier))
+        let resultsAfterDeletion = try sqliteService.select(byQuery: .videoForSpecipic(day: "2022-11-22 00:12:34".toDate()!))
+        XCTAssertEqual(resultsAfterDeletion.count, 0)
+    }
+    
+    
     private func createDateString(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> String {
         return "\(year)-\(month)-\(day) \(hour):\(minute):\(second)"
     }

--- a/IKU/PersistenceTest/VideoURLServiceTest.swift
+++ b/IKU/PersistenceTest/VideoURLServiceTest.swift
@@ -36,4 +36,33 @@ final class VideoURLServiceTest: XCTestCase {
         let url = try videoURLService.fetchVideoURL(named: "test")
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path()))
     }
+    
+    func test_delete_video() throws {
+        let testFileURL = try testFileURLWithCreatingFile()
+        let testFileName = "test"
+        try videoURLService.moveURLToVideoFolder(testFileURL, withChangingNameTo: testFileName)
+        let allFileNamesBeforeDeletion = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
+        XCTAssertEqual(allFileNamesBeforeDeletion.count, 1)
+        XCTAssertEqual(allFileNamesBeforeDeletion.first, "test.mp4")
+        try videoURLService.deleteVideoURL(named: testFileName)
+        let allFileNamesAfterDeletion = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
+        XCTAssertEqual(allFileNamesAfterDeletion.count, 0)
+    }
+    
+    func test_delete_video_if_it_only_delete_specific_file() throws {
+        let testFileOneURL = try testFileURLWithCreatingFile()
+        let testFileOneName = "testOne"
+        try videoURLService.moveURLToVideoFolder(testFileOneURL, withChangingNameTo: testFileOneName)
+        let testFileTwoURL = try testFileURLWithCreatingFile()
+        let testFileTwoName = "testTwo"
+        try videoURLService.moveURLToVideoFolder(testFileTwoURL, withChangingNameTo: testFileTwoName)
+        
+        let allFileNamesBeforeDeletion = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
+        XCTAssertEqual(allFileNamesBeforeDeletion.count, 2)
+        
+        try videoURLService.deleteVideoURL(named: testFileTwoName)
+        let allFileNamesAfterDeletion = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
+        XCTAssertEqual(allFileNamesAfterDeletion.count, 1)
+        XCTAssertEqual(allFileNamesAfterDeletion.first, testFileOneName + ".mp4")
+    }
 }


### PR DESCRIPTION
# 이슈번호
🔓 open #39 

# 내용
- 영구저장소에서 삭제 함수가 사용 가능합니다.
- 삭제를 하게 되면
  - SQLiteService에서 MeasurementResult에 해당하는 값을 제거합니다.
  - JSONService에서 사시각 측정 결과를 삭제합니다.
  - VideoURLService에서 영상 자료인 .mp3를 삭제합니다.

# 테스트 방법(Optional)
- UnitTest 참조 바랍니다.

# 여담

![스크린샷 2022-11-23 오후 10 55 44](https://user-images.githubusercontent.com/81242125/203571551-3b73ac6f-9afe-4db6-86d4-620a2a5c481b.jpg)

- 이거 때문에 2시간 고생했는데, TEXT에 대한 SQL 문법이 달라서 생긴 문제였습니다....
