### PR TITLE
[D1] MeasurementResult 리펙토링

### DIFF
--- a/IKU/IKU.xcodeproj/project.pbxproj
+++ b/IKU/IKU.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9E8BEE4E29234CDD00AB2E44 /* StoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8BEE4D29234CDD00AB2E44 /* StoryView.swift */; };
 		A804661A291FF9890079CEDC /* ScrubberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8046619291FF9890079CEDC /* ScrubberView.swift */; };
 		A804661C292012B10079CEDC /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804661B292012B10079CEDC /* PlayButton.swift */; };
+		A8096C80292F0C5B00CBBC41 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8096C7F292F0C5B00CBBC41 /* String+Extension.swift */; };
 		A897ED6E29277CC000C93E22 /* MeasurementResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A897ED6D29277CC000C93E22 /* MeasurementResult.swift */; };
 		A89F22FA292B7079000B3D63 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89F22F9292B7079000B3D63 /* XCTestCase+Extension.swift */; };
 		A89F2300292B95C0000B3D63 /* MeasurementResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A897ED6D29277CC000C93E22 /* MeasurementResult.swift */; };
@@ -121,6 +122,7 @@
 		9E8BEE4D29234CDD00AB2E44 /* StoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryView.swift; sourceTree = "<group>"; };
 		A8046619291FF9890079CEDC /* ScrubberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrubberView.swift; sourceTree = "<group>"; };
 		A804661B292012B10079CEDC /* PlayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayButton.swift; sourceTree = "<group>"; };
+		A8096C7F292F0C5B00CBBC41 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A897ED6D29277CC000C93E22 /* MeasurementResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementResult.swift; sourceTree = "<group>"; };
 		A89F22F9292B7079000B3D63 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
 		A89F2306292BB3A6000B3D63 /* VideoURLService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoURLService.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 				A8FA007E292B45E00091EDC2 /* JSONServiceTest.swift */,
 				A89F2308292BB3B0000B3D63 /* VideoURLServiceTest.swift */,
 				A89F22F9292B7079000B3D63 /* XCTestCase+Extension.swift */,
+				A8096C7F292F0C5B00CBBC41 /* String+Extension.swift */,
 			);
 			path = PersistenceTest;
 			sourceTree = "<group>";
@@ -637,6 +640,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A8FA007F292B45E00091EDC2 /* JSONServiceTest.swift in Sources */,
+				A8096C80292F0C5B00CBBC41 /* String+Extension.swift in Sources */,
 				A89F230F292BB650000B3D63 /* PersistenceManager.swift in Sources */,
 				A89F230E292BB64D000B3D63 /* PersistenceManagerTest.swift in Sources */,
 				A89F2309292BB3B0000B3D63 /* VideoURLServiceTest.swift in Sources */,

--- a/IKU/IKU/Data/MeasurementResult.swift
+++ b/IKU/IKU/Data/MeasurementResult.swift
@@ -12,6 +12,6 @@ struct MeasurementResult: Codable {
     let isLeftEye: Bool
     let timeOne: Double
     let timeTwo: Double
-    let creationDate: Double
+    let creationDate: Date
     let isBookMarked: Bool
 }

--- a/IKU/IKU/Manager/PersistenceManager.swift
+++ b/IKU/IKU/Manager/PersistenceManager.swift
@@ -47,18 +47,10 @@ final class PersistenceManager {
         isLeftEye: Bool,
         uncoveredPhotoTime: Double,
         coveredPhotoTime: Double,
-        creationDate: Double = Date.now.timeIntervalSince1970,
+        creationDate: Date = Date.now,
         isBookMarked: Bool = false
     ) throws {
         let newFileName = UUID().uuidString
-        let measurementResult = MeasurementResult(
-            localIdentifier: newFileName,
-            isLeftEye: isLeftEye,
-            timeOne: uncoveredPhotoTime,
-            timeTwo: coveredPhotoTime,
-            creationDate: creationDate,
-            isBookMarked: isBookMarked
-        )
         try jsonService.save(
             toFileName: newFileName,
             with: dictionay
@@ -67,7 +59,16 @@ final class PersistenceManager {
             videoURL,
             withChangingNameTo: newFileName
         )
-        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: newFileName,
+                eye: isLeftEye ? 1 : 0,
+                timeOne: uncoveredPhotoTime,
+                timeTwo: coveredPhotoTime,
+                creationTimeinterval: creationDate.timeIntervalSince1970,
+                bookmark: isBookMarked ? 1 : 0
+            )
+        )
     }
     
     func fetchVideo(_ day: Term) throws -> [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] {

--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -26,7 +26,7 @@ final class PersistenceManagerTest: XCTestCase {
 
     func test_save_video_without_prefixed_values() throws {
         try persistenceManager.save(
-            videoURL: try testFileURLWithCreatingFile(),
+            videoURL: try exampleFileURLWithCreatingFile(),
             withARKitResult: [:],
             isLeftEye: true,
             uncoveredPhotoTime: 0,
@@ -36,24 +36,25 @@ final class PersistenceManagerTest: XCTestCase {
     
     func test_save_video_with_all_values() throws {
         try persistenceManager.save(
-            videoURL: try testFileURLWithCreatingFile(),
+            videoURL: try exampleFileURLWithCreatingFile(),
             withARKitResult: [:],
             isLeftEye: true,
             uncoveredPhotoTime: 0,
             coveredPhotoTime: 1.2,
-            creationDate: Date.now.timeIntervalSince1970,
+            creationDate: Date.now,
             isBookMarked: false
         )
     }
     
     func test_fetch_all_video() throws {
+        let currentDate = "2022-11-22 00:12:34".toDate()!
         try persistenceManager.save(
-            videoURL: try testFileURLWithCreatingFile(),
+            videoURL: try exampleFileURLWithCreatingFile(),
             withARKitResult: [2.2:3.3],
             isLeftEye: true,
             uncoveredPhotoTime: 0,
             coveredPhotoTime: 1.2,
-            creationDate: 1234567,
+            creationDate: currentDate,
             isBookMarked: false
         )
         let result = try persistenceManager.fetchVideo(.all)
@@ -62,7 +63,7 @@ final class PersistenceManagerTest: XCTestCase {
         XCTAssertEqual(result.first?.measurementResult.isLeftEye, true)
         XCTAssertEqual(result.first?.measurementResult.timeOne, 0)
         XCTAssertEqual(result.first?.measurementResult.timeTwo, 1.2)
-        XCTAssertEqual(result.first?.measurementResult.creationDate, 1234567)
+        XCTAssertEqual(result.first?.measurementResult.creationDate, currentDate)
         XCTAssertEqual(result.first?.measurementResult.isBookMarked, false)
     }
     
@@ -93,7 +94,7 @@ final class PersistenceManagerTest: XCTestCase {
     }
     
     func test_clear_garbage_files() throws {
-        _ = try testFileURLWithCreatingFile()
+        _ = try exampleFileURLWithCreatingFile()
         var expectedFiles: Set<String> = ["example.mp4", "strabismusAngles", "videos", "IKU.sqlite"]
         
         for fileName in try allFileNamesInDocumentDirectory() {

--- a/IKU/PersistenceTest/SQLiteServiceTest.swift
+++ b/IKU/PersistenceTest/SQLiteServiceTest.swift
@@ -23,16 +23,17 @@ final class SQLiteServiceTest: XCTestCase {
     }
 
     func test_table_select_data_of_same_day() throws {
-        let measurementResult = MeasurementResult(
-            localIdentifier: "localIdentifier",
-            isLeftEye: true,
-            timeOne: 0,
-            timeTwo: 1.2,
-            creationDate: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
-            isBookMarked: false
-        )
         try sqliteService.createTableIfNotExist(byQuery: .videoTable)
-        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: "localIdentifier",
+                eye: 1,
+                timeOne: 0,
+                timeTwo: 1.2,
+                creationTimeinterval: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
+                bookmark: 0
+            )
+        )
         
         for day in 21...23 {
             for hour in 0...23 {
@@ -45,7 +46,7 @@ final class SQLiteServiceTest: XCTestCase {
                     XCTAssertEqual(array.first?.isLeftEye, true)
                     XCTAssertEqual(array.first?.timeOne, 0)
                     XCTAssertEqual(array.first?.timeTwo, 1.2)
-                    XCTAssertEqual(array.first?.creationDate, "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970)
+                    XCTAssertEqual(array.first?.creationDate, "2022-11-22 00:12:34".toDate())
                     XCTAssertEqual(array.first?.isBookMarked, false)
                 } else {
                     XCTAssertEqual(array.count, 0)
@@ -57,15 +58,16 @@ final class SQLiteServiceTest: XCTestCase {
     func test_table_select_all() throws {
         try sqliteService.createTableIfNotExist(byQuery: .videoTable)
         for number in 1...10 {
-            let measurementResult = MeasurementResult(
-                localIdentifier: String(number),
-                isLeftEye: true,
-                timeOne: 0,
-                timeTwo: 0,
-                creationDate: "2022-11-\(String(format: "%02d", number)) 00:12:34".toDate()!.timeIntervalSince1970,
-                isBookMarked: false
+            try sqliteService.insert(
+                byQuery: .videoData(
+                    localIdentifier: String(number),
+                    eye: 1,
+                    timeOne: 0,
+                    timeTwo: 1.2,
+                    creationTimeinterval: Double(number),
+                    bookmark: 0
+                )
             )
-            try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
         }
         let array = try sqliteService.select(byQuery: .allVideos)
         XCTAssertEqual(array.count, 10)
@@ -113,13 +115,5 @@ final class SQLiteServiceTest: XCTestCase {
     
     private func createDateString(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> String {
         return "\(year)-\(month)-\(day) \(hour):\(minute):\(second)"
-    }
-}
-
-private extension String {
-    func toDate() -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return dateFormatter.date(from: self)
     }
 }

--- a/IKU/PersistenceTest/String+Extension.swift
+++ b/IKU/PersistenceTest/String+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  String+Extension.swift
+//  PersistenceTest
+//
+//  Created by Shin Jae Ung on 2022/11/24.
+//
+
+import Foundation
+
+extension String {
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return dateFormatter.date(from: self)
+    }
+}

--- a/IKU/PersistenceTest/VideoURLServiceTest.swift
+++ b/IKU/PersistenceTest/VideoURLServiceTest.swift
@@ -23,7 +23,7 @@ final class VideoURLServiceTest: XCTestCase {
     }
 
     func test_move_URL_to_folder() throws {
-        let testFileURL = try testFileURLWithCreatingFile()
+        let testFileURL = try exampleFileURLWithCreatingFile()
         try videoURLService.moveURLToVideoFolder(testFileURL, withChangingNameTo: "test")
         let allFileNames = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
         XCTAssertEqual(allFileNames.count, 1)
@@ -31,7 +31,7 @@ final class VideoURLServiceTest: XCTestCase {
     }
     
     func test_fetch_video_url() throws {
-        let testFileURL = try testFileURLWithCreatingFile()
+        let testFileURL = try exampleFileURLWithCreatingFile()
         try videoURLService.moveURLToVideoFolder(testFileURL, withChangingNameTo: "test")
         let url = try videoURLService.fetchVideoURL(named: "test")
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path()))

--- a/IKU/PersistenceTest/XCTestCase+Extension.swift
+++ b/IKU/PersistenceTest/XCTestCase+Extension.swift
@@ -27,7 +27,7 @@ extension XCTestCase {
         return try FileManager.default.contentsOfDirectory(atPath: dbURL.path())
     }
     
-    func testFileURLWithCreatingFile() throws -> URL {
+    func exampleFileURLWithCreatingFile() throws -> URL {
         let testData = "example".data(using: .utf8)
         let testFileURL = try documentFolderURL().appendingPathComponent("example.mp4")
         FileManager.default.createFile(atPath: testFileURL.path(), contents: testData)


### PR DESCRIPTION
# 배경
🔓 open #39

# 내용
- MeasurementResult가 creationDate를 Timeinterval type으로 소유하고 있습니다.
- 때문에 혼돈이 생겨 이를 Date type으로 소유하도록 변경하였습니다.
- 이 과정에서 SQLiteService를 비롯한 객체들의 매개변수가 변경되었고, 이를 리팩토링 하였습니다.

# 테스트 방법(Optional)
- UnitTest 참고 바랍니다.
