### PR TITLE
[D0] MeasurementResult 변경으로 인한 영구저장소 삭제 기능 Test 변경

### DIFF
--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -75,12 +75,12 @@ final class PersistenceManagerTest: XCTestCase {
     
     func test_delete_video() throws {
         try persistenceManager.save(
-            videoURL: try testFileURLWithCreatingFile(),
+            videoURL: try exampleFileURLWithCreatingFile(),
             withARKitResult: [2.2:3.3],
             isLeftEye: true,
             uncoveredPhotoTime: 0,
             coveredPhotoTime: 1.2,
-            creationDate: 1234567,
+            creationDate: "2022-11-22 00:12:34".toDate()!,
             isBookMarked: false
         )
         let resultsBeforeDeletion = try persistenceManager.fetchVideo(.all)

--- a/IKU/PersistenceTest/SQLiteServiceTest.swift
+++ b/IKU/PersistenceTest/SQLiteServiceTest.swift
@@ -75,16 +75,17 @@ final class SQLiteServiceTest: XCTestCase {
     
     func test_delete_data() throws {
         let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
-        let measurementResult = MeasurementResult(
-            localIdentifier: localIdentifier,
-            isLeftEye: true,
-            timeOne: 0,
-            timeTwo: 1.2,
-            creationDate: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
-            isBookMarked: false
-        )
         try sqliteService.createTableIfNotExist(byQuery: .videoTable)
-        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: localIdentifier,
+                eye: 1,
+                timeOne: 0,
+                timeTwo: 1.2,
+                creationTimeinterval: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
+                bookmark: 0
+            )
+        )
         
         XCTAssertNoThrow(
             try sqliteService.delete(byQuery: .videoData(withLocalIdentifier: localIdentifier))
@@ -93,16 +94,17 @@ final class SQLiteServiceTest: XCTestCase {
     
     func test_delete_data_and_check_if_it_exists() throws {
         let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
-        let measurementResult = MeasurementResult(
-            localIdentifier: localIdentifier,
-            isLeftEye: true,
-            timeOne: 0,
-            timeTwo: 1.2,
-            creationDate: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
-            isBookMarked: false
-        )
         try sqliteService.createTableIfNotExist(byQuery: .videoTable)
-        try sqliteService.insert(byQuery: .videoData(measurementResult: measurementResult))
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: localIdentifier,
+                eye: 1,
+                timeOne: 0,
+                timeTwo: 1.2,
+                creationTimeinterval: "2022-11-22 00:12:34".toDate()!.timeIntervalSince1970,
+                bookmark: 0
+            )
+        )
         
         let resultsBeforeDeletion = try sqliteService.select(byQuery: .videoForSpecipic(day: "2022-11-22 00:12:34".toDate()!))
         XCTAssertEqual(resultsBeforeDeletion.count, 1)

--- a/IKU/PersistenceTest/VideoURLServiceTest.swift
+++ b/IKU/PersistenceTest/VideoURLServiceTest.swift
@@ -38,7 +38,7 @@ final class VideoURLServiceTest: XCTestCase {
     }
     
     func test_delete_video() throws {
-        let testFileURL = try testFileURLWithCreatingFile()
+        let testFileURL = try exampleFileURLWithCreatingFile()
         let testFileName = "test"
         try videoURLService.moveURLToVideoFolder(testFileURL, withChangingNameTo: testFileName)
         let allFileNamesBeforeDeletion = try allFileNamesInDocumentDirectory(appendingPathComponent: VideoURLService.path)
@@ -50,10 +50,10 @@ final class VideoURLServiceTest: XCTestCase {
     }
     
     func test_delete_video_if_it_only_delete_specific_file() throws {
-        let testFileOneURL = try testFileURLWithCreatingFile()
+        let testFileOneURL = try exampleFileURLWithCreatingFile()
         let testFileOneName = "testOne"
         try videoURLService.moveURLToVideoFolder(testFileOneURL, withChangingNameTo: testFileOneName)
-        let testFileTwoURL = try testFileURLWithCreatingFile()
+        let testFileTwoURL = try exampleFileURLWithCreatingFile()
         let testFileTwoName = "testTwo"
         try videoURLService.moveURLToVideoFolder(testFileTwoURL, withChangingNameTo: testFileTwoName)
         


### PR DESCRIPTION
# 이슈번호
🔓 open #39 

# 내용
- MeasurementResult 값이 변경됨에 따라 삭제 테스트에서 변경사항이 발생하여 build가 되지 않습니다.
- 정상 동작하도록 변경하였습니다.

# 테스트 방법(Optional)
- UnitTest 참고
