### PR TITLE
[D2] 영구저장소에서 영상 북마크와 가림 frame의 시간, 안가림 frame의 시간 변경 기능

### DIFF
--- a/IKU/IKU/Manager/PersistenceManager.swift
+++ b/IKU/IKU/Manager/PersistenceManager.swift
@@ -86,6 +86,29 @@ final class PersistenceManager {
         try sqliteService.delete(byQuery: .videoData(withLocalIdentifier: localIdentifier))
     }
     
+    func updateVideo(withLocalIdentifier localIdentifier: String, bookmarked bookmark: Bool) throws {
+        try sqliteService.update(
+            byQuery: .videoBookmarkData(
+                withLocalIdentifier: localIdentifier,
+                setTo: bookmark ? 1 : 0
+            )
+        )
+    }
+    
+    func updateVideo(
+        withLocalIdentifier localIdentifier: String,
+        setUncoveredPhotoTimeTo uncoveredPhotoTime: Double,
+        setCoveredPhotoTimeTo coveredPhotoTime: Double
+    ) throws {
+        try sqliteService.update(
+            byQuery: .videoTimeOneAndTimeTwoData(
+                withLocalIdentifier: localIdentifier,
+                setTimeOneTo: uncoveredPhotoTime,
+                setTimeTwoTo: coveredPhotoTime
+            )
+        )
+    }
+    
     private func fetchVideo(from measurementResults: [MeasurementResult]) throws -> [(videoURL: URL, angles: [Double: Double], measurementResult: MeasurementResult)] {
         return try measurementResults.map { measurementResult in
             let fileName = measurementResult.localIdentifier

--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -93,6 +93,66 @@ final class PersistenceManagerTest: XCTestCase {
         XCTAssertEqual(resultsAfterDeletion.count, 0)
     }
     
+    func test_update_video_bookmark() throws {
+        try persistenceManager.save(
+            videoURL: try exampleFileURLWithCreatingFile(),
+            withARKitResult: [2.2:3.3],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2,
+            creationDate: "2022-11-22 00:12:34".toDate()!,
+            isBookMarked: false
+        )
+        let resultsBeforeUpdate = try persistenceManager.fetchVideo(.all)
+        guard let resultBeforeUpdate = resultsBeforeUpdate.first?.measurementResult else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertFalse(resultBeforeUpdate.isBookMarked)
+        
+        try persistenceManager.updateVideo(withLocalIdentifier: resultBeforeUpdate.localIdentifier, bookmarked: true)
+        
+        let resultsAfterUpdate = try persistenceManager.fetchVideo(.all)
+        guard let resultAfterUpdate = resultsAfterUpdate.first?.measurementResult else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertTrue(resultAfterUpdate.isBookMarked)
+    }
+    
+    func test_update_video_uncoverd_photo_time_and_covered_photo_time() throws {
+        try persistenceManager.save(
+            videoURL: try exampleFileURLWithCreatingFile(),
+            withARKitResult: [2.2:3.3],
+            isLeftEye: true,
+            uncoveredPhotoTime: 0,
+            coveredPhotoTime: 1.2,
+            creationDate: "2022-11-22 00:12:34".toDate()!,
+            isBookMarked: false
+        )
+        let resultsBeforeUpdate = try persistenceManager.fetchVideo(.all)
+        guard let resultBeforeUpdate = resultsBeforeUpdate.first?.measurementResult else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertEqual(resultBeforeUpdate.timeOne, 0)
+        XCTAssertEqual(resultBeforeUpdate.timeTwo, 1.2)
+        
+        try persistenceManager.updateVideo(
+            withLocalIdentifier: resultBeforeUpdate.localIdentifier,
+            setUncoveredPhotoTimeTo: 11,
+            setCoveredPhotoTimeTo: 2.2
+        )
+        
+        let resultsAfterUpdate = try persistenceManager.fetchVideo(.all)
+        guard let resultAfterUpdate = resultsAfterUpdate.first?.measurementResult else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertEqual(resultAfterUpdate.timeOne, 11)
+        XCTAssertEqual(resultAfterUpdate.timeTwo, 2.2)
+    }
+    
     func test_clear_garbage_files() throws {
         _ = try exampleFileURLWithCreatingFile()
         var expectedFiles: Set<String> = ["example.mp4", "strabismusAngles", "videos", "IKU.sqlite"]

--- a/IKU/PersistenceTest/SQLiteServiceTest.swift
+++ b/IKU/PersistenceTest/SQLiteServiceTest.swift
@@ -114,6 +114,70 @@ final class SQLiteServiceTest: XCTestCase {
         XCTAssertEqual(resultsAfterDeletion.count, 0)
     }
     
+    func test_update_bookmark() throws {
+        let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
+        let creationTime = "2022-11-22 00:12:34".toDate()!
+        try sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: localIdentifier,
+                eye: 1,
+                timeOne: 0,
+                timeTwo: 1.2,
+                creationTimeinterval: creationTime.timeIntervalSince1970,
+                bookmark: 0
+            )
+        )
+        guard let resultBeforeUpdate = try sqliteService.select(byQuery: .videoForSpecipic(day: creationTime)).first else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertFalse(resultBeforeUpdate.isBookMarked)
+        
+        try sqliteService.update(byQuery: .videoBookmarkData(withLocalIdentifier: localIdentifier, setTo: 1))
+        guard let resultBeforeUpdate = try sqliteService.select(byQuery: .videoForSpecipic(day: creationTime)).first else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertTrue(resultBeforeUpdate.isBookMarked)
+    }
+    
+    func test_update_time_one_and_time_two() throws {
+        let localIdentifier = "E3C929C3-3B49-480E-A47B-A8479F40A4C2"
+        let creationTime = "2022-11-22 00:12:34".toDate()!
+        try sqliteService.createTableIfNotExist(byQuery: .videoTable)
+        try sqliteService.insert(
+            byQuery: .videoData(
+                localIdentifier: localIdentifier,
+                eye: 1,
+                timeOne: 0,
+                timeTwo: 1.2,
+                creationTimeinterval: creationTime.timeIntervalSince1970,
+                bookmark: 0
+            )
+        )
+        guard let resultBeforeUpdate = try sqliteService.select(byQuery: .videoForSpecipic(day: creationTime)).first else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertEqual(resultBeforeUpdate.timeOne, 0)
+        XCTAssertEqual(resultBeforeUpdate.timeTwo, 1.2)
+        
+        try sqliteService.update(
+            byQuery: .videoTimeOneAndTimeTwoData(
+                withLocalIdentifier: localIdentifier,
+                setTimeOneTo: 11,
+                setTimeTwoTo: 2.2
+            )
+        )
+        guard let resultBeforeUpdate = try sqliteService.select(byQuery: .videoForSpecipic(day: creationTime)).first else {
+            XCTAssert(false)
+            return
+        }
+        XCTAssertEqual(resultBeforeUpdate.timeOne, 11)
+        XCTAssertEqual(resultBeforeUpdate.timeTwo, 2.2)
+    }
+    
     
     private func createDateString(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> String {
         return "\(year)-\(month)-\(day) \(hour):\(minute):\(second)"


### PR DESCRIPTION
# 이슈번호
🔓 open #39

# 내용
- 영구저장소에서 특정 Video에 대해 북마크 값을 업데이트할 수 있습니다.
- 영구저장소에서 특정 Video에 대해 가림, 안가림으로 등록된 시간을 변경할 수 있습니다.

# 테스트 방법(Optional)
- UnitTest 확인바랍니다.