### PR TITLE
[D0] 머지 후 빌드 에러 해결

### DIFF
--- a/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarDayView.swift
+++ b/IKU/IKU/Views/ViewModule/IKUCalendarView/CVCalendar/CVCalendarDayView.swift
@@ -110,7 +110,7 @@ public final class CVCalendarDayView: UIView {
             .receive(on: DispatchQueue.main)
             .map {
                 return !($0.map { result in
-                    let dataDate = Date(timeIntervalSince1970: .init(result.measurementResult.creationDate))
+                    let dataDate = result.measurementResult.creationDate
                     return (Calendar.current.compare(dataDate, to: self.date.getDate(), toGranularity: .day) == .orderedSame)
                 }.contains(true))
             }


### PR DESCRIPTION
# 이슈번호
🔐 close #111 

# 내용
- measurementResult 내의 creationDate가 Double에서 Date로 변경됨에 따라 빌드가 불가한 에러를 수정하였습니다.

# 테스트 방법(Optional)
- UnitTest 및 빌드 성공하면 됩니다.