### PR TITLE
[D1] HistoryView에 ProfileView 갈 수 있는 Navigation BarButtonItem 추가

### DIFF
--- a/IKU/IKU.xcodeproj/project.pbxproj
+++ b/IKU/IKU.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 78F54XW75V;
+				DEVELOPMENT_TEAM = Z629PZ4XVL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IKU/App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
@@ -838,7 +838,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 78F54XW75V;
+				DEVELOPMENT_TEAM = Z629PZ4XVL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IKU/App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";

--- a/IKU/IKU/Views/HistoryListViewController.swift
+++ b/IKU/IKU/Views/HistoryListViewController.swift
@@ -23,7 +23,7 @@ class HistoryListViewController: UIViewController {
         let backItem = UIBarButtonItem()
         backItem.title = ""
         navigationItem.backBarButtonItem = backItem
-        title = "List"
+        title = "Test List"
         
         let barButtonItemImage = UIImage(systemName: "bookmark",
                                          withConfiguration: UIImage.SymbolConfiguration(pointSize: 17, weight: .medium, scale: .medium))

--- a/IKU/IKU/Views/HistoryViewController.swift
+++ b/IKU/IKU/Views/HistoryViewController.swift
@@ -50,9 +50,43 @@ final class HistoryViewController: UIViewController {
     
     // MARK: - Methods
     private func setupNavigationController() {
+        // Navigation Back Button
         let backItem = UIBarButtonItem()
         backItem.title = ""
         navigationItem.backBarButtonItem = backItem
+        
+        // Navigation Title View
+        let label = UILabel()
+        label.text = "Test Record"
+        label.font = .nexonGothicFont(ofSize: 17, weight: .bold)
+        label.textColor = .black
+        label.textAlignment = .center
+        navigationItem.titleView = label
+        
+        // Right UIBarButtonItem
+        let barButtonlabel = UILabel()
+        barButtonlabel.text = "Lisa"
+        barButtonlabel.font = .nexonGothicFont(ofSize: 13, weight: .bold)
+        barButtonlabel.textColor = .black
+        barButtonlabel.textAlignment = .center
+        
+        let imageView = UIImageView(image: UIImage(named: "AppIcon"))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 25),
+            imageView.heightAnchor.constraint(equalToConstant: 25),
+        ])
+        imageView.layer.cornerRadius = 25 / 2
+        imageView.clipsToBounds = true
+        
+        let itemStackView = UIStackView(arrangedSubviews: [barButtonlabel, imageView])
+        itemStackView.axis = .horizontal
+        itemStackView.spacing = 3
+        itemStackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(goToProfileView(_:))))
+        
+        let barButtonItem = UIBarButtonItem(customView: itemStackView)
+        navigationItem.rightBarButtonItem = barButtonItem
     }
     
     private func setupCalendarView() {
@@ -137,6 +171,10 @@ final class HistoryViewController: UIViewController {
                 }
             }
         }
+    }
+    
+    @objc private func goToProfileView(_ sender: UIStackView) {
+        navigationController?.pushViewController(ProfileViewController(), animated: true)
     }
     
     // MARK: - Life Cycles


### PR DESCRIPTION
# 이슈번호
🔐 close #136 

# 내용
- HistoryView의 Navigation Title을 표시하였습니다.
- HistoryView에서 ProfileView로 이동할 수 있습니다.

# 테스트 방법(Optional)
- HistoryView 우측 상단의 이름+사진 으로 되어있는 버튼을 누르면 됩니다.

# 스크린샷(Optional)
![IMG_48CCA466F71C-1](https://user-images.githubusercontent.com/47404421/204146459-adb002c7-110a-4578-bb9a-b4291568f399.jpeg)
