### PR TITLE
[D1] CoverTestView의 Navigation Bar 수정

### DIFF
--- a/IKU/IKU.xcodeproj/project.pbxproj
+++ b/IKU/IKU.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 78F54XW75V;
+				DEVELOPMENT_TEAM = Z629PZ4XVL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IKU/App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
@@ -838,7 +838,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 78F54XW75V;
+				DEVELOPMENT_TEAM = Z629PZ4XVL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IKU/App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";

--- a/IKU/IKU/Views/CoverTestViewController.swift
+++ b/IKU/IKU/Views/CoverTestViewController.swift
@@ -137,6 +137,7 @@ final class CoverTestViewController: UIViewController {
                                             action: #selector(touchCloseButton(_:)))
         navigationItem.leftBarButtonItem = barButtonItem
         navigationItem.titleView = distanceLabel
+        navigationController?.navigationBar.scrollEdgeAppearance = nil
     }
     
     private func setupARScene() {

--- a/IKU/IKU/Views/HistoryViewController.swift
+++ b/IKU/IKU/Views/HistoryViewController.swift
@@ -22,7 +22,7 @@ final class HistoryViewController: UIViewController {
     private var todayStatusLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "우리아이의 사시각 오늘도 검사완료!"
+        label.text = ""
         label.font = .nexonGothicFont(ofSize: 17)
         label.textColor = .black
         label.textAlignment = .center
@@ -53,6 +53,13 @@ final class HistoryViewController: UIViewController {
         let backItem = UIBarButtonItem()
         backItem.title = ""
         navigationItem.backBarButtonItem = backItem
+        
+        let label = UILabel()
+        label.text = "Test Record"
+        label.font = .nexonGothicFont(ofSize: 17, weight: .bold)
+        label.textColor = .black
+        label.textAlignment = .center
+        navigationItem.titleView = label
     }
     
     private func setupCalendarView() {

--- a/IKU/IKU/Views/StoryView.swift
+++ b/IKU/IKU/Views/StoryView.swift
@@ -22,7 +22,7 @@ struct StoryView: View {
     init() {
         let appearence = UINavigationBarAppearance()
         appearence.shadowColor = .black
-        UINavigationBar.appearance().standardAppearance = appearence
+        appearence.backgroundColor = .ikuBackground
         UINavigationBar.appearance().scrollEdgeAppearance = appearence
     }
     


### PR DESCRIPTION
# 이슈번호
🔐 close #138 

# 내용
- CoverTestView의 Navigation Bar이 색상이 Figma와 동일하게 표시되도록 수정하였습니다.

# 테스트 방법(Optional)
- CoverTestView를 통해 확인할 수 있습니다.