### PR TITLE
[D0] 유닛테스트 첫 1회 실패 버그

### DIFF
--- a/IKU/PersistenceTest/PersistenceManagerTest.swift
+++ b/IKU/PersistenceTest/PersistenceManagerTest.swift
@@ -154,6 +154,7 @@ final class PersistenceManagerTest: XCTestCase {
     }
     
     func test_clear_garbage_files() throws {
+        try persistenceManager.clearGarbageFilesInDocumentFolder()
         _ = try exampleFileURLWithCreatingFile()
         var expectedFiles: Set<String> = ["example.mp4", SQLiteService.path, JSONService.path, VideoURLService.path]
         


### PR DESCRIPTION
# 이슈번호
🔐 close #141 

# 내용
- UnitTest를 처음 실행시 Document folder에 "com.apple.springboard.appLibrary"라는 파일이 생깁니다.
- 이 파일을 제거 후 UnitTest를 시작합니다.

# 테스트 방법(Optional)
- UnitTest 실행




