### PR TITLE
[D1] 사시 검사 화면에서 눈 선택 View를 조금 더 Figma와 비슷하게 변경

### DIFF
--- a/IKU/IKU/Views/StoryView.swift
+++ b/IKU/IKU/Views/StoryView.swift
@@ -184,24 +184,20 @@ fileprivate struct EyeSelectingView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
-            ZStack {
-                switch selectedEye {
-                case .left:
-                    Image("LeftEyeSelectedImage")
-                        .resizable()
-                        .scaledToFit()
-                case .right:
-                    Image("RightEyeSelectedImage")
-                        .resizable()
-                        .scaledToFit()
-                }
+        Group {
+            switch selectedEye {
+            case .left:
+                Image("LeftEyeSelectedImage")
+                    .resizable()
+                    .scaledToFit()
+            case .right:
+                Image("RightEyeSelectedImage")
+                    .resizable()
+                    .scaledToFit()
             }
-            .position(
-                x: geometry.frame(in: .local).midX,
-                y: geometry.frame(in: .local).midY
-            )
-            .overlay{
+        }
+        .overlay{
+            GeometryReader { geometry in
                 ZStack {
                     Rectangle()
                         .opacity(0.47)
@@ -220,7 +216,6 @@ fileprivate struct EyeSelectingView: View {
                             case .right: selectedEye = .left
                             }
                         }
-                        
                     VStack {
                         Spacer()
                         HStack{
@@ -236,10 +231,10 @@ fileprivate struct EyeSelectingView: View {
                     }
                 }
             }
-            .clipShape(
-                RoundedRectangle(cornerRadius: 10)
-            )
         }
+        .clipShape(
+            RoundedRectangle(cornerRadius: 10)
+        )
     }
     
     private func Mask(direction eye: Eye, in rect: CGRect) -> some View {
@@ -250,7 +245,6 @@ fileprivate struct EyeSelectingView: View {
                 size: CGSize(width: rect.width/2 - 8, height: rect.height - 8))
             )
         )
-        
         return shape.fill(style: FillStyle(eoFill: true))
     }
 }


### PR DESCRIPTION
# 이슈번호
🔐 close #41 

# 내용
- 눈 선택 기능을 Figma와 비슷하게 변경하였습니다.
  - GeometryReader가 화면 전체를 차지하려고 하는 현상을 해결하였습니다.

# 테스트 방법(Optional)
- 사시 검사 화면을 확인합니다.

# 스크린샷(Optional)

|이전|변경|피그마|
|:-:|:-:|:-:|
|<img width=200 src="https://user-images.githubusercontent.com/81242125/205803881-098cfa2d-030d-4d7a-8369-3feffeecfc2c.jpeg">|<img width=200 src="https://user-images.githubusercontent.com/81242125/205803758-4011f0e0-fc54-4db3-b8a7-befefae9ca06.jpeg">|<img width=200 src="https://user-images.githubusercontent.com/81242125/205804117-6ff152b0-9ed4-4e4b-a5a1-e4cd8edd4f7f.jpeg">|