### PR TITLE
[D0] Frame 선택 화면 무한 반복 버그 해결

### DIFF
--- a/IKU/IKU/Views/SelectPhotoViewController.swift
+++ b/IKU/IKU/Views/SelectPhotoViewController.swift
@@ -229,6 +229,7 @@ final class SelectPhotoViewController: UIViewController {
         self.urlPath = urlPath
         self.degrees = degrees
         self.selectedEye = selectedEye
+        self.capturedImage = capturedImage
         self.recommandedUncoverFrameTime = recommandedUncoverFrameTime
         self.recommandedCoverFrameTime = recommandedCoverFrameTime
         self.scrubberView = ScrubberView(


### PR DESCRIPTION
# 이슈번호
🔐 close #179 

# 내용
- Frame 선택 화면에서 Frame을 선택하더라도 다음 화면으로 넘어가지 않고 동일한 화면으로만 계속 넘어가는 현상 해결

# 테스트 방법(Optional)
- Frame 선택 화면에서 우측 상단 선택하기 버튼 누르면 됩니다.