### PR TITLE
[D0] Replay Button이 안나오는 버그 해결

### DIFF
--- a/IKU/IKU/Views/HistoryListViewController.swift
+++ b/IKU/IKU/Views/HistoryListViewController.swift
@@ -156,6 +156,7 @@ extension HistoryListViewController: UITableViewDelegate, UITableViewDataSource 
                 let cellDate = cellData.measurementResult.creationDate
                 return Calendar.current.compare(date, to: cellDate, toGranularity: .day) == .orderedSame
             }
+            resultViewController.isReplayButtonHidden = false
             resultViewController.prepareData(data: datas, showedEye: cellData.measurementResult.isLeftEye ? .left : .right)
             resultViewController.root = .history_list
             navigationController?.pushViewController(resultViewController, animated: true)


### PR DESCRIPTION
# 이슈번호
🔐 close #190 

# 내용
- List에서 접근한 ResultView에서도 Replay Button이 나옵니다.

# 테스트 방법(Optional)
- 검사 결과를 하나 이상 만듭니다.
- Record 탭으로 넘어갑니다.
- 캘린더에서 돋보기 이모티콘이 붙은 것을 눌러 들어간 결과 화면에서 Replay Button이 존재합니다.
- 뒤로 돌아갑니다.
- 캘린더 우측 상단의 버튼을 눌러 리스트로 변경합니다.
- 리스트 중 하나를 선택하여 들어간 결과화면에서 Replay Button이 존재하는지 확인합니다.